### PR TITLE
Make Na channels TTX sensitive

### DIFF
--- a/mod_files/na3n.mod
+++ b/mod_files/na3n.mod
@@ -2,10 +2,12 @@ TITLE na3
 : Na current 
 : modified from Jeff Magee. M.Migliore may97
 : added sh to account for higher threshold M.Migliore, Apr.2002
+: WVG @ BBP 2018: add ttx sensitivity
 
 NEURON {
 	SUFFIX na3
 	USEION na READ ena WRITE ina
+    USEION ttx READ ttxo, ttxi VALENCE 1
 	RANGE  gbar, ar, sh
 	GLOBAL minf, hinf, mtau, htau, sinf, taus,qinf, thinf
 }
@@ -56,6 +58,8 @@ UNITS {
 } 
 
 ASSIGNED {
+    ttxo        (mM)
+    ttxi        (mM)
 	ina 		(mA/cm2)
 	thegna		(mho/cm2)
 	minf 		hinf 		
@@ -73,7 +77,17 @@ BREAKPOINT {
 } 
 
 INITIAL {
-	trates(v,ar,sh)
+    if (ttxi == 0.015625 && ttxo > 1e-12) {
+        minf = 0.0
+        mtau = 1e-12
+        hinf = 1.0
+        htau = 1e-12
+        sinf = 0.0
+        taus = 1e-12
+    } else {
+        trates(v,ar,sh)      
+    }
+
 	m=minf  
 	h=hinf
 	s=sinf
@@ -94,11 +108,21 @@ FUNCTION bets(v(mV)) {
 
 LOCAL mexp, hexp, sexp
 
-DERIVATIVE states {   
+DERIVATIVE states { 
+    if (ttxi == 0.015625 && ttxo > 1e-12) {
+        minf = 0.0
+        mtau = 1e-12
+        hinf = 1.0
+        htau = 1e-12
+        sinf = 0.0
+        taus = 1e-12
+    } else {
         trates(v,ar,sh)      
-        m' = (minf-m)/mtau
-        h' = (hinf-h)/htau
-        s' = (sinf - s)/taus
+    }
+
+    m' = (minf-m)/mtau
+    h' = (hinf-h)/htau
+    s' = (sinf - s)/taus
 }
 
 PROCEDURE trates(vm,a2,sh2) {  

--- a/mod_files/naxn.mod
+++ b/mod_files/naxn.mod
@@ -6,6 +6,7 @@ TITLE nax
 NEURON {
 	SUFFIX nax
 	USEION na READ ena WRITE ina
+    USEION ttx READ ttxo, ttxi VALENCE 1
 	RANGE  gbar, sh
 	GLOBAL minf, hinf, mtau, htau,thinf, qinf
 }
@@ -46,6 +47,8 @@ UNITS {
 } 
 
 ASSIGNED {
+    ttxo        (mM)
+    ttxi        (mM)
 	ina 		(mA/cm2)
 	thegna		(mho/cm2)
 	minf 		hinf 		
@@ -62,13 +65,29 @@ BREAKPOINT {
 } 
 
 INITIAL {
-	trates(v,sh)
+    if (ttxi == 0.015625 && ttxo > 1e-12) {
+        minf = 0.0
+        mtau = 1e-12
+        hinf = 1.0
+        htau = 1e-12
+    } else {
+        trates(v,sh)      
+    }
+
 	m=minf  
 	h=hinf
 }
 
 DERIVATIVE states {   
+    if (ttxi == 0.015625 && ttxo > 1e-12) {
+        minf = 0.0
+        mtau = 1e-12
+        hinf = 1.0
+        htau = 1e-12
+    } else {
         trates(v,sh)      
+    }
+    
         m' = (minf-m)/mtau
         h' = (hinf-h)/htau
 }

--- a/mod_files/naxn.mod
+++ b/mod_files/naxn.mod
@@ -2,6 +2,7 @@ TITLE nax
 : Na current for axon. No slow inact.
 : M.Migliore Jul. 1997
 : added sh to account for higher threshold M.Migliore, Apr.2002
+: WVG @ BBP 2018: add ttx sensitivity
 
 NEURON {
 	SUFFIX nax


### PR DESCRIPTION
Slightly change the code to make the Na channels sensitive to TTX concentration.

(This is necessary to make these channels work with TTX functionality in Neurodamus / PSP validation)